### PR TITLE
Initial pass at deployment scripts for kubemeta and easier configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,11 @@ Additional settings can be found in [kustomization-template.yml](kustomization-t
 `deploy-kube.sh` is the deployment script.
 
 To run `deploy-kube.sh`, you'll need to have at least one kubernetes context and your Kentik plan information:
-- Plan ID number
+- Your Kentik Plan ID number
 - Your Kentik registered email address
 - Your Kentik token/API key
-- Your device name (e.g., the name of the Kubernetes cluster)
+- Your cloud provider name (e.g., aws)
+- Your kubernetes cluster name
 
 ## Kube Installation
 ### Clone this repo

--- a/README.md
+++ b/README.md
@@ -4,9 +4,18 @@ kappa-cfg contains example Kubernetes deployment descriptors for
 kappa. These descriptors utilize kustomize which is available in
 kubectl v1.14+.
 
-Most user-serviceable settings are configured via the config map
-and secret generators in [kustomization.yml](kustomization.yml).
+Most user-serviceable settings are configured via the configuration section in [deploy-kube.sh](deploy-kube.sh).
+Additional settings can be found in [kustomization.yml](kustomization.yml).
 
-## usage
+`deploy-kube.sh` is the deployment script.
 
-`kubectl apply -k .`
+## usage examples
+
+`deploy-kube.sh -h` This will show you basic usage of the deployment script.
+
+All the below will deploy kubemeta, kappa agents, and kappa aggregator into a k8s cluster.
+
+- `deploy-kube.sh` Deploy into the k8s cluster as defined by the context in `~/.kube/config`
+- `deploy-kube.sh -f <path-to-kube-config-file>` Deploy into the k8s cluster as defined by the context in the specified config file.
+- `deploy-kube.sh -c <k8s-context>` Deploy into the k8s cluster as defined by a specific context in `~/.kube/config`
+- `deploy-kube.sh -f <path-to-kube-config-file> -c <k8s-context>` Deploy into the k8s cluster as defined by the specified context in the specified config file.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,36 @@
-# kappa-cfg - kubernetes configs for kappa
+# kube-cfg - Kube configuration and deployment to Kubernetes
 
-kappa-cfg contains example Kubernetes deployment descriptors for
-kappa. These descriptors utilize kustomize which is available in
-kubectl v1.14+.
+kube-cfg contains the Kubernetes deployment descriptors necessary to deploy the kube components into a Kubernetes
+cluster. These descriptors utilize kustomize which is available in kubectl v1.14+.
 
 Most user-serviceable settings are configured via the configuration section in [deploy-kube.sh](deploy-kube.sh).
-Additional settings can be found in [kustomization.yml](kustomization.yml).
+Additional settings can be found in [kustomization-template.yml](kustomization-template.yml).
 
 `deploy-kube.sh` is the deployment script.
 
-## usage examples
+To run `deploy-kube.sh`, you'll need to have at least one kubernetes context and your Kentik plan information:
+- Plan ID number
+- Your Kentik registered email address
+- Your Kentik token/API key
+- Your device name (e.g., the name of the Kubernetes cluster)
+
+## Kube Installation
+### Clone this repo
+```bash
+git clone https://github.com/kentik/kube-cfg.git
+cd kube-cfg
+```
+
+### Configure the script
+Edit the `USER CONFIGURATION` section at the very top of `deploy-kube.sh`. This is where you'll set your Kentik plan
+information.
+
+### Run `deploy-kube.sh`
+```bash
+./deploy-kube.sh
+```
+
+## deploy-kube.sh optional flags
 
 `deploy-kube.sh -h` This will show you basic usage of the deployment script.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# kube-cfg - Kube configuration and deployment to Kubernetes
+# kentik-kube-deploy - Kube configuration and deployment to Kubernetes
 
-kube-cfg contains the Kubernetes deployment descriptors necessary to deploy the kube components into a Kubernetes
+kentik-kube-deploy contains the Kubernetes deployment descriptors necessary to deploy the kube components into a Kubernetes
 cluster. These descriptors utilize kustomize which is available in kubectl v1.14+.
 
 Most user-serviceable settings are configured via the configuration section in [deploy-kube.sh](deploy-kube.sh).
@@ -18,8 +18,8 @@ To run `deploy-kube.sh`, you'll need to have at least one kubernetes context and
 ## Kube Installation
 ### Clone this repo
 ```bash
-git clone https://github.com/kentik/kube-cfg.git
-cd kube-cfg
+git clone https://github.com/kentik/kentik-kube-deploy.git
+cd kentik-kube-deploy
 ```
 
 ### Configure the script

--- a/deploy-kube.sh
+++ b/deploy-kube.sh
@@ -16,7 +16,7 @@ PLAN=0123456789
 EMAIL=customer_email@example.com
 TOKEN=123abc_your_customer_kentik_token_cba321
 CLUSTER=your_cluster_name
-CLOUDPROVIDER=aws_or_gcp_etc
+CLOUDPROVIDER=aws_or_gcp_or_azure_or_prem
 #
 # CAPTURE already has a workable default.  Don't change this unless you know
 # for sure it's what you want.
@@ -48,6 +48,24 @@ while getopts 'c:f:h' flag; do
         *) display_help ;;
     esac
 done
+
+# Check for valid CLOUDPROVIDER value
+valid_providers=("aws" "gcp" "azure" "prem")
+is_valid_provider=false
+
+for provider in "${valid_providers[@]}"; do
+    if [[ "$CLOUDPROVIDER" == "$provider" ]]; then
+        is_valid_provider=true
+        break
+    fi
+done
+
+if [[ "$is_valid_provider" == false ]]; then
+    echo
+    echo "Error: Invalid CLOUDPROVIDER value ($CLOUDPROVIDER). Must be one of: aws, gcp, azure, or prem"
+    echo
+    exit 1
+fi
 
 echo "Going to apply the kube yaml configuration with the following values:"
 echo

--- a/deploy-kube.sh
+++ b/deploy-kube.sh
@@ -15,7 +15,8 @@
 PLAN=0123456789
 EMAIL=customer_email@example.com
 TOKEN=123abc_your_customer_kentik_token_cba321
-DEVICE=your_device_name
+CLUSTER=your_cluster_name
+CLOUDPROVIDER=aws_or_gcp_etc
 #
 # CAPTURE already has a workable default.  Don't change this unless you know
 # for sure it's what you want.
@@ -50,10 +51,11 @@ done
 
 echo "Going to apply the kube yaml configuration with the following values:"
 echo
-echo "Plan:   $PLAN"
-echo "Device: $DEVICE"
-echo "Email:  $EMAIL"
-echo "Token:  $TOKEN"
+echo "Plan:    $PLAN"
+echo "Email:   $EMAIL"
+echo "Token:   $TOKEN"
+echo "Cloud:   $CLOUD"
+echo "Cluster: $CLUSTER"
 echo
 echo "Capture: $CAPTURE"
 echo
@@ -64,8 +66,14 @@ if [[ ! "${confirmation}" =~ ^[yY]$ ]]; then
     exit 1
 fi
 
-sed 's/__CAPTURE__/'"$CAPTURE"'/g; s/__DEVICE__/'"$DEVICE"'/g; s/__EMAIL__/'"$EMAIL"'/g; s/__TOKEN__/'"$TOKEN"'/g' \
-    kustomization-template.yml > kustomization.yml
+sed 's/__CAPTURE__/'"$CAPTURE"'/g; '\
+    's/__CLOUD__/'"$CLOUDPROVIDER"'/g; '\
+    's/__CLUSTER__/'"$CLUSTER"'/g; '\
+    's/__EMAIL__/'"$EMAIL"'/g; '\
+    's/__PLAN__/'"$PLAN"'/g; '\
+    's/__TOKEN__/'"$TOKEN"'/g' \
+     kustomization-template.yml > kustomization.yml
+
 
 # Set kubeconfig and context variables if provided
 KUBECONF=""

--- a/deploy-kube.sh
+++ b/deploy-kube.sh
@@ -20,7 +20,7 @@ DEVICE=your_device_name
 # CAPTURE already has a workable default.  Don't change this unless you know
 # for sure it's what you want.
 #
-CAPTURE='ens*|veth.*|eth*'
+CAPTURE='en*|veth.*|eth*'
 # ######################
 #
 #   END CONFIGURATION

--- a/deploy-kube.sh
+++ b/deploy-kube.sh
@@ -9,10 +9,18 @@
 # kubernetes cluster)
 #
 # ######################
-PLAN=1234567890
+#
+# You must set these four as appropriate for your account and device
+#
+PLAN=0123456789
 EMAIL=customer_email@example.com
-TOKEN=123abc_customer_kentik_token_cba321
-DEVICE=a_device_name
+TOKEN=123abc_your_customer_kentik_token_cba321
+DEVICE=your_device_name
+#
+# CAPTURE already has a workable default.  Don't change this unless you know
+# for sure it's what you want.
+#
+CAPTURE='ens3|veth.*|eth*'
 # ######################
 #
 #   END CONFIGURATION
@@ -42,10 +50,12 @@ done
 
 echo "Going to apply the kube yaml configuration with the following values:"
 echo
-echo "Plan: $PLAN"
+echo "Plan:   $PLAN"
 echo "Device: $DEVICE"
-echo "Email: $EMAIL"
-echo "Token: $TOKEN"
+echo "Email:  $EMAIL"
+echo "Token:  $TOKEN"
+echo
+echo "Capture: $CAPTURE"
 echo
 read -p "Do you want to proceed (y/n)? " confirmation
 
@@ -54,7 +64,7 @@ if [[ ! "${confirmation}" =~ ^[yY]$ ]]; then
     exit 1
 fi
 
-sed "s/__PLAN__/$PLAN/g; s/__DEVICE__/$DEVICE/g; s/__EMAIL__/$EMAIL/g; s/__TOKEN__/$TOKEN/g" \
+sed 's/__CAPTURE__/'"$CAPTURE"'/g; s/__DEVICE__/'"$DEVICE"'/g; s/__EMAIL__/'"$EMAIL"'/g; s/__TOKEN__/'"$TOKEN"'/g' \
     kustomization-template.yml > kustomization.yml
 
 # Set kubeconfig and context variables if provided

--- a/deploy-kube.sh
+++ b/deploy-kube.sh
@@ -54,7 +54,7 @@ echo
 echo "Plan:    $PLAN"
 echo "Email:   $EMAIL"
 echo "Token:   $TOKEN"
-echo "Cloud:   $CLOUD"
+echo "Cloud:   $CLOUDPROVIDER"
 echo "Cluster: $CLUSTER"
 echo
 echo "Capture: $CAPTURE"
@@ -66,14 +66,14 @@ if [[ ! "${confirmation}" =~ ^[yY]$ ]]; then
     exit 1
 fi
 
-sed 's/__CAPTURE__/'"$CAPTURE"'/g; '\
-    's/__CLOUD__/'"$CLOUDPROVIDER"'/g; '\
-    's/__CLUSTER__/'"$CLUSTER"'/g; '\
-    's/__EMAIL__/'"$EMAIL"'/g; '\
-    's/__PLAN__/'"$PLAN"'/g; '\
-    's/__TOKEN__/'"$TOKEN"'/g' \
-     kustomization-template.yml > kustomization.yml
-
+sed \
+    -e 's/__CAPTURE__/'"$CAPTURE"'/g' \
+    -e 's/__CLOUDPROVIDER__/'"$CLOUDPROVIDER"'/g' \
+    -e 's/__CLUSTER__/'"$CLUSTER"'/g' \
+    -e 's/__EMAIL__/'"$EMAIL"'/g' \
+    -e 's/__PLAN__/'"$PLAN"'/g' \
+    -e 's/__TOKEN__/'"$TOKEN"'/g' \
+    kustomization-template.yml > kustomization.yml
 
 # Set kubeconfig and context variables if provided
 KUBECONF=""

--- a/deploy-kube.sh
+++ b/deploy-kube.sh
@@ -20,7 +20,7 @@ DEVICE=your_device_name
 # CAPTURE already has a workable default.  Don't change this unless you know
 # for sure it's what you want.
 #
-CAPTURE='ens3|veth.*|eth*'
+CAPTURE='ens*|veth.*|eth*'
 # ######################
 #
 #   END CONFIGURATION

--- a/deploy-kube.sh
+++ b/deploy-kube.sh
@@ -12,16 +12,16 @@
 #
 # You must set these four as appropriate for your account and device
 #
-PLAN=5354
-EMAIL=tma+kentikdemonew@kentik.com
-TOKEN=c381ac67174620173f41d0c0dabdb07c
-CLUSTER=gke-cluster-kentik-standard
-CLOUDPROVIDER=gcp
+PLAN=0123456789
+EMAIL=customer_email@example.com
+TOKEN=123abc_your_customer_kentik_token_cba321
+CLUSTER=your_cluster_name
+CLOUDPROVIDER=aws_or_gcp_or_azure_or_prem
 #
 # Don't change the below values unless you know for sure it's what you want.
 #
 CAPTURE='en*|veth.*|eth*'
-KUBEMETA_VERSION=sha-c9723a0
+KUBEMETA_VERSION=sha-68b9457
 # ######################
 #
 #   END CONFIGURATION
@@ -86,25 +86,14 @@ if [[ ! "${confirmation}" =~ ^[yY]$ ]]; then
 fi
 
 sed \
-    -e 's/__CAPTURE__/'"$CAPTURE"'/g' \
+    -e 's/__CAPTURE__/'\"$CAPTURE\"'/g' \
     -e 's/__CLOUDPROVIDER__/'"$CLOUDPROVIDER"'/g' \
     -e 's/__CLUSTER__/'"$CLUSTER"'/g' \
     -e 's/__EMAIL__/'"$EMAIL"'/g' \
+    -e 's/__KUBEMETA_VERSION__/'\"$KUBEMETA_VERSION\"'/g' \
     -e 's/__PLAN__/'"$PLAN"'/g' \
     -e 's/__TOKEN__/'"$TOKEN"'/g' \
     kustomization-template.yml > kustomization.yml
-
-SEDCMD="s/__KUBEMETA_VERSION__/$KUBEMETA_VERSION/"
-OS=$(uname)
-
-# macOS's sed behaves a little differently
-if [[ "$OS" == "Darwin" ]]; then
-    # macOS (BSD sed)
-    sed -i '' "$SED_COMMAND" kubemeta.yml
-else
-    # Linux (GNU sed)
-    sed -i "$SED_COMMAND" kubemeta.yml
-fi
 
 # Set kubeconfig and context variables if provided
 KUBECONF=""

--- a/deploy-kube.sh
+++ b/deploy-kube.sh
@@ -12,11 +12,11 @@
 #
 # You must set these four as appropriate for your account and device
 #
-PLAN=0123456789
-EMAIL=customer_email@example.com
-TOKEN=123abc_your_customer_kentik_token_cba321
-CLUSTER=your_cluster_name
-CLOUDPROVIDER=aws_or_gcp_or_azure_or_prem
+PLAN=5354
+EMAIL=tma+kentikdemonew@kentik.com
+TOKEN=c381ac67174620173f41d0c0dabdb07c
+CLUSTER=gke-cluster-kentik-standard
+CLOUDPROVIDER=gcp
 #
 # Don't change the below values unless you know for sure it's what you want.
 #
@@ -94,7 +94,17 @@ sed \
     -e 's/__TOKEN__/'"$TOKEN"'/g' \
     kustomization-template.yml > kustomization.yml
 
-sed -i "s/__KUBEMETA_VERSION__/$KUBEMETA_VERSION/" kubemeta.yml
+SEDCMD="s/__KUBEMETA_VERSION__/$KUBEMETA_VERSION/"
+OS=$(uname)
+
+# macOS's sed behaves a little differently
+if [[ "$OS" == "Darwin" ]]; then
+    # macOS (BSD sed)
+    sed -i '' "$SED_COMMAND" kubemeta.yml
+else
+    # Linux (GNU sed)
+    sed -i "$SED_COMMAND" kubemeta.yml
+fi
 
 # Set kubeconfig and context variables if provided
 KUBECONF=""

--- a/deploy-kube.sh
+++ b/deploy-kube.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# ######################
+#
+#   USER CONFIGURATION
+#
+# change the below values to match your kentik plan number, your email/token
+# associated with your kentik account, and the device in question (e.g., a
+# kubernetes cluster)
+#
+# ######################
+PLAN=1234567890
+EMAIL=customer_email@example.com
+TOKEN=123abc_customer_kentik_token_cba321
+DEVICE=a_device_name
+# ######################
+#
+#   END CONFIGURATION
+#
+# ######################
+
+K8S_CONTEXT=""
+KUBECONFIG_FILE=""
+
+function display_help() {
+    echo "Usage: $0 [-c <k8s context>] [-f <k8s config file>]"
+    echo "  -c  Specify the Kubernetes context. (optional)"
+    echo "  -f  Specify the kubeconfig file to use. (optional)"
+    echo "  -h  Display this help message."
+    exit 1
+}
+
+# some optional commandline args
+while getopts 'c:f:h' flag; do
+    case "${flag}" in
+        c) K8S_CONTEXT="${OPTARG}" ;;
+        f) KUBECONFIG_FILE="${OPTARG}" ;;
+        h) display_help ;;
+        *) display_help ;;
+    esac
+done
+
+echo "Going to apply the kube yaml configuration with the following values:"
+echo
+echo "Plan: $PLAN"
+echo "Device: $DEVICE"
+echo "Email: $EMAIL"
+echo "Token: $TOKEN"
+echo
+read -p "Do you want to proceed (y/n)? " confirmation
+
+if [[ ! "${confirmation}" =~ ^[yY]$ ]]; then
+    echo "Aborted."
+    exit 1
+fi
+
+sed "s/__PLAN__/$PLAN/g; s/__DEVICE__/$DEVICE/g; s/__EMAIL__/$EMAIL/g; s/__TOKEN__/$TOKEN/g" \
+    kustomization-template.yml > kustomization.yml
+
+# Set kubeconfig and context variables if provided
+KUBECONF=""
+KUBECONTEXT=""
+[[ -n "$KUBECONFIG_FILE" ]] && KUBECONF="KUBECONFIG=\"$KUBECONFIG_FILE\""
+[[ -n "$K8S_CONTEXT" ]] && KUBECONTEXT="--context=\"$K8S_CONTEXT\""
+
+eval $KUBECONF kubectl apply -k . $KUBECONTEXT

--- a/deploy-kube.sh
+++ b/deploy-kube.sh
@@ -18,10 +18,10 @@ TOKEN=123abc_your_customer_kentik_token_cba321
 CLUSTER=your_cluster_name
 CLOUDPROVIDER=aws_or_gcp_or_azure_or_prem
 #
-# CAPTURE already has a workable default.  Don't change this unless you know
-# for sure it's what you want.
+# Don't change the below values unless you know for sure it's what you want.
 #
 CAPTURE='en*|veth.*|eth*'
+KUBEMETA_VERSION=sha-c9723a0
 # ######################
 #
 #   END CONFIGURATION
@@ -69,13 +69,14 @@ fi
 
 echo "Going to apply the kube yaml configuration with the following values:"
 echo
-echo "Plan:    $PLAN"
-echo "Email:   $EMAIL"
-echo "Token:   $TOKEN"
-echo "Cloud:   $CLOUDPROVIDER"
-echo "Cluster: $CLUSTER"
+echo "Plan:     $PLAN"
+echo "Email:    $EMAIL"
+echo "Token:    $TOKEN"
+echo "Cloud:    $CLOUDPROVIDER"
+echo "Cluster:  $CLUSTER"
 echo
-echo "Capture: $CAPTURE"
+echo "Capture:  $CAPTURE"
+echo "Kubemeta: $KUBEMETA_VERSION"
 echo
 read -p "Do you want to proceed (y/n)? " confirmation
 
@@ -92,6 +93,8 @@ sed \
     -e 's/__PLAN__/'"$PLAN"'/g' \
     -e 's/__TOKEN__/'"$TOKEN"'/g' \
     kustomization-template.yml > kustomization.yml
+
+sed -i "s/__KUBEMETA_VERSION__/$KUBEMETA_VERSION/" kubemeta.yml
 
 # Set kubeconfig and context variables if provided
 KUBECONF=""

--- a/kubemeta.yml
+++ b/kubemeta.yml
@@ -48,7 +48,7 @@ spec:
       serviceAccountName: kubemeta
       containers:
         - name: kubemeta
-          image: kentik/kubemeta:sha-c9723a0
+          image: kentik/kubemeta
           imagePullPolicy: Always
           args:
             - "--check-interval"

--- a/kubemeta.yml
+++ b/kubemeta.yml
@@ -48,7 +48,7 @@ spec:
       serviceAccountName: kubemeta
       containers:
         - name: kubemeta
-          image: kentik/kubemeta:latest
+          image: kentik/kubemeta:sha-c9723a0
           imagePullPolicy: Always
           args:
             - "--check-interval"

--- a/kubemeta.yml
+++ b/kubemeta.yml
@@ -25,7 +25,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: kubemeta
-    namespace: default
+    namespace: kentik
 roleRef:
   kind: ClusterRole
   name: kubemeta
@@ -49,5 +49,28 @@ spec:
       containers:
         - name: kubemeta
           image: kentik/kubemeta:latest
-          args: ["--check-interval", "20"]
+          args:
+            - "--check-interval"
+            - "20"
+          env:
+            - name: CLOUD
+              valueFrom:
+                configMapKeyRef:
+                  name: kube-config
+                  key: cloudprovider
+            - name: KENTIK_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: kentik-api-secrets
+                  key: email
+            - name: KENTIK_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: kentik-api-secrets
+                  key: token
+            - name: CLUSTER_NAME
+              valueFrom:
+                configMapKeyRef:
+                  name: kappa-config
+                  key: device
           imagePullPolicy: Always

--- a/kubemeta.yml
+++ b/kubemeta.yml
@@ -63,7 +63,7 @@ spec:
                 secretKeyRef:
                   name: kentik-api-secrets
                   key: email
-            - name: KENTIK_TOKEN
+            - name: KENTIK_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: kentik-api-secrets

--- a/kubemeta.yml
+++ b/kubemeta.yml
@@ -49,6 +49,7 @@ spec:
       containers:
         - name: kubemeta
           image: kentik/kubemeta:latest
+          imagePullPolicy: Always
           args:
             - "--check-interval"
             - "20"
@@ -73,4 +74,3 @@ spec:
                 configMapKeyRef:
                   name: kappa-config
                   key: device
-          imagePullPolicy: Always

--- a/kubemeta.yml
+++ b/kubemeta.yml
@@ -1,0 +1,53 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubemeta
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubemeta
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces", "nodes", "pods", "services"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["apps"]
+    resources: ["deployments", "replicasets"]
+    verbs: ["list", "watch"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses"]
+    verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubemeta
+subjects:
+  - kind: ServiceAccount
+    name: kubemeta
+    namespace: default
+roleRef:
+  kind: ClusterRole
+  name: kubemeta
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kubemeta-deployment
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kubemeta
+  template:
+    metadata:
+      labels:
+        app: kubemeta
+    spec:
+      serviceAccountName: kubemeta
+      containers:
+        - name: kubemeta
+          image: kentik/kubemeta:latest
+          args: ["--check-interval", "20"]
+          imagePullPolicy: Always

--- a/kustomization-template.yml
+++ b/kustomization-template.yml
@@ -13,7 +13,7 @@ configMapGenerator:
   - name: kappa-config
     literals:
       - capture=__CAPTURE__
-      - device=__DEVICE__
+      - device=__CLUSTER__
       - region=US
       - plan=__PLAN__
       - bytecode=x86_64/kappa_bpf-ubuntu-5.4.o
@@ -22,6 +22,9 @@ configMapGenerator:
       - init/exec
       - init/fetch
       - init/trace
+  - name: kube-config
+    literals:
+      - cloudprovider=__CLOUDPROVIDER__
 patchesJson6902:
 #   - target:
 #       group: "apps"

--- a/kustomization-template.yml
+++ b/kustomization-template.yml
@@ -8,7 +8,7 @@ images:
   - name: kentik/kappa
     newTag: "1.1.1"
   - name: kentik/kubemeta
-    newTag: "latest"
+    newTag: __KUBEMETA_VERSION__
 configMapGenerator:
   - name: kappa-config
     literals:

--- a/kustomization-template.yml
+++ b/kustomization-template.yml
@@ -3,10 +3,13 @@ resources:
   - namespace.yml
   - kappa-agent.yml
   - kappa-agg.yml
+  - kubeinfo.yml
   - kubemeta.yml
 images:
   - name: kentik/kappa
     newTag: "1.1.1"
+  - name: kentik/kubeinfo
+    newTag: "1.0.1"
   - name: kentik/kubemeta
     newTag: __KUBEMETA_VERSION__
 configMapGenerator:

--- a/kustomization-template.yml
+++ b/kustomization-template.yml
@@ -12,7 +12,7 @@ images:
 configMapGenerator:
   - name: kappa-config
     literals:
-      - capture=ens3|veth.*
+      - capture=__CAPTURE__
       - device=__DEVICE__
       - region=US
       - plan=__PLAN__

--- a/kustomization-template.yml
+++ b/kustomization-template.yml
@@ -7,8 +7,8 @@ resources:
 images:
   - name: kentik/kappa
     newTag: "1.1.1"
-  - name: kentik/kubeinfo
-    newTag: "1.0.1"
+  - name: kentik/kubemeta
+    newTag: "latest"
 configMapGenerator:
   - name: kappa-config
     literals:

--- a/kustomization-template.yml
+++ b/kustomization-template.yml
@@ -3,7 +3,7 @@ resources:
   - namespace.yml
   - kappa-agent.yml
   - kappa-agg.yml
-  - kubeinfo.yml
+  - kubemeta.yml
 images:
   - name: kentik/kappa
     newTag: "1.1.1"
@@ -13,9 +13,9 @@ configMapGenerator:
   - name: kappa-config
     literals:
       - capture=ens3|veth.*
-      - device=kappa_test
+      - device=__DEVICE__
       - region=US
-      - plan=1234
+      - plan=__PLAN__
       - bytecode=x86_64/kappa_bpf-ubuntu-5.4.o
   - name: kappa-init
     files:
@@ -32,5 +32,5 @@ patchesJson6902:
 secretGenerator:
   - name: kentik-api-secrets
     literals:
-      - email=test@example.com
-      - token=asdf1234
+      - email=__EMAIL__
+      - token=__TOKEN__


### PR DESCRIPTION
Add kubemeta.yml for kubemeta deployment.

Also, add `deploy-kube.sh` as the deployment script to allow for easier configuration for deployments.  This script will create a local `kustomization.yml` file based on applying the configuration options in the script to the `kustomization-template.yml` file.

This PR also removes `kubeinfo` from the default deployment, though the `kubeinfo.yml` is still here for now.  Once we have confidence that `kubemeta` is doing what we need, we'll remove `kubeinfo` entirely.