### PR TITLE
Account Region and Kappa Sample Ratio are Configurable

### DIFF
--- a/deploy-kube.sh
+++ b/deploy-kube.sh
@@ -12,17 +12,19 @@
 #
 # You must set these four as appropriate for your account and device
 #
+ACCOUNTREGION=US
 PLAN=0123456789
 EMAIL=customer_email@example.com
 TOKEN=123abc_your_customer_kentik_token_cba321
-CLUSTER=your_cluster_name
 CLOUDPROVIDER=aws_or_gcp_or_azure_or_prem
+CLUSTER=your_cluster_name
 #
 # Don't change the below values unless you know for sure it's what you want.
 #
 CAPTURE='en*|veth.*|eth*'
 KUBEMETA_VERSION=sha-6589ba8
 MAX_PAYLOAD_SIZE_MB=8
+KAPPA_SAMPLE_RATIO=1:4
 # ######################
 #
 #   END CONFIGURATION
@@ -74,15 +76,17 @@ MAX_PAYLOAD_SIZE_BYTES=$((MAX_PAYLOAD_SIZE_MB * 1024 * 1024))
 
 echo "Going to apply the kube yaml configuration with the following values:"
 echo
-echo "Plan:       $PLAN"
-echo "Email:      $EMAIL"
-echo "Token:      $TOKEN"
-echo "Cloud:      $CLOUDPROVIDER"
-echo "Cluster:    $CLUSTER"
+echo "Account Region: $ACCOUNTREGION"
+echo "Plan:           $PLAN"
+echo "Email:          $EMAIL"
+echo "Token:          $TOKEN"
+echo "Cloud:          $CLOUDPROVIDER"
+echo "Cluster:        $CLUSTER"
 echo
-echo "Capture:    $CAPTURE"
-echo "Kubemeta:   $KUBEMETA_VERSION"
-echo "MaxPayload: ${MAX_PAYLOAD_SIZE_MB}MB"
+echo "Capture:        $CAPTURE"
+echo "Kappa Sample:   $KAPPA_SAMPLE_RATIO"
+echo "Kubemeta:       $KUBEMETA_VERSION"
+echo "MaxPayload:     ${MAX_PAYLOAD_SIZE_MB}MB"
 echo
 read -p "Do you want to proceed (y/n)? " confirmation
 
@@ -91,11 +95,27 @@ if [[ ! "${confirmation}" =~ ^[yY]$ ]]; then
     exit 1
 fi
 
+case $ACCOUNTREGION in
+    US)
+        GRPCENDPOINT="grpc.api.kentik.com"
+        ;;
+    EU)
+        GRPCENDPOINT="grpc.api.kentik.eu"
+        ;;
+    *)
+        echo "Unknown account region: $ACCOUNTREGION"
+        exit 1
+        ;;
+esac
+
 sed \
+    -e 's/__ACCOUNTREGION__/'"$ACCOUNTREGION"'/g' \
     -e 's/__CAPTURE__/'\"$CAPTURE\"'/g' \
     -e 's/__CLOUDPROVIDER__/'"$CLOUDPROVIDER"'/g' \
     -e 's/__CLUSTER__/'"$CLUSTER"'/g' \
     -e 's/__EMAIL__/'"$EMAIL"'/g' \
+    -e 's/__GRPCENDPOINT__/'"$GRPCENDPOINT"'/g' \
+    -e 's/__KAPPA_SAMPLE_RATIO__/'"$KAPPA_SAMPLE_RATIO"'/g' \
     -e 's/__KUBEMETA_VERSION__/'\"$KUBEMETA_VERSION\"'/g' \
     -e 's/__MAXGRPCPAYLOAD__/'"$MAX_PAYLOAD_SIZE_BYTES"'/g' \
     -e 's/__PLAN__/'"$PLAN"'/g' \

--- a/kappa-agent.yml
+++ b/kappa-agent.yml
@@ -29,7 +29,7 @@ spec:
             - "--capture"
             - "$(capture)"
             - "--sample"
-            - "1:4"
+            - "$(sampleratio)"
             - "$(KAPPA_AGG_SERVICE_HOST):4000"
           envFrom:
             - configMapRef:

--- a/kubemeta.yml
+++ b/kubemeta.yml
@@ -53,6 +53,8 @@ spec:
           args:
             - "--check-interval"
             - "20"
+            - "--addr"
+            - "$(GRPC_ENDPOINT):443"
           env:
             - name: CLOUD
               valueFrom:
@@ -74,6 +76,11 @@ spec:
                 configMapKeyRef:
                   name: kappa-config
                   key: device
+            - name: GRPC_ENDPOINT
+              valueFrom:
+                configMapKeyRef:
+                  name: kube-config
+                  key: grpcendpoint
             - name: MAX_PAYLOAD_SIZE
               valueFrom:
                 configMapKeyRef:

--- a/kustomization-template.yml
+++ b/kustomization-template.yml
@@ -17,8 +17,9 @@ configMapGenerator:
     literals:
       - capture=__CAPTURE__
       - device=__CLUSTER__
-      - region=US
+      - region=__ACCOUNTREGION__
       - plan=__PLAN__
+      - sampleratio=__KAPPA_SAMPLE_RATIO__
       - bytecode=x86_64/kappa_bpf-ubuntu-5.4.o
   - name: kappa-init
     files:
@@ -28,6 +29,7 @@ configMapGenerator:
   - name: kube-config
     literals:
       - cloudprovider=__CLOUDPROVIDER__
+      - grpcendpoint=__GRPCENDPOINT__
       - maxgrpcpayload=__MAXGRPCPAYLOAD__
 patchesJson6902:
 #   - target:


### PR DESCRIPTION
Accounts are only authorized to access the gRPC endpoint in the same region as the account.  US accounts are authorized to use `grpc.api.kentik.com:443` and EU accounts are authorized to use `grpc.api.kentik.eu:443`.

Previously, the account region was hard configured to US.  Changing that to EU required manually modification of the .yaml files and manually adding a command line option to `kubemeta.yml`.

This PR consolidates and moves the account region configuration into `deploy-kube.sh`, including deriving the appropriate gRPC endpoint.

This PR also moves the kappa sample ratio, previously hard configured as 1:4, into `deploy-kube.sh`