### PR TITLE
Support for multiple identically named clusters for a company: added uuid gen, cloud region, environment label

### DIFF
--- a/deploy-kube.sh
+++ b/deploy-kube.sh
@@ -17,13 +17,15 @@ PLAN=0123456789
 EMAIL=customer_email@example.com
 TOKEN=123abc_your_customer_kentik_token_cba321
 CLOUDPROVIDER=aws_or_gcp_or_azure_or_prem
+CLOUDREGION=eg_us-west-2_or_something_custom_for_prem
+ENVIRONMENT=free_form_such_as_production_or_staging_or_dev_or_custom
 CLUSTER=your_cluster_name
 #
 # Don't change the below values unless you know for sure it's what you want.
 #
 CAPTURE='en*|veth.*|eth*'
 KUBEMETA_VERSION=sha-6589ba8
-MAX_PAYLOAD_SIZE_MB=8
+MAX_PAYLOAD_SIZE_MB=16
 KAPPA_SAMPLE_RATIO=1:4
 # ######################
 #
@@ -40,6 +42,74 @@ function display_help() {
     echo "  -f  Specify the kubeconfig file to use. (optional)"
     echo "  -h  Display this help message."
     exit 1
+}
+
+get_or_create_cluster_uuid() {
+  local config_map_name="kentik-config"
+  local uuid_key="cluster-uuid"
+  local lock_name="kentik-config-lock"
+  local lock_timeout=300 # Adjust the lock timeout as needed (e.g., 5 minutes)
+
+  # Attempt to retrieve the UUID from the config map
+  local uuid=$(kubectl get configmap "$config_map_name" -o jsonpath="{.data.$uuid_key}" 2>/dev/null)
+
+  if [[ -n "$uuid" ]]; then
+    echo "$uuid"
+    return 0
+  fi
+
+  # UUID not found in the config map, generate a new one
+  local new_uuid=$(uuidgen)
+
+  # Safely create or update the config map using a lock
+  if kubectl create configmap "$lock_name" --from-literal=lock=true &>/dev/null; then
+    # Lock acquired, proceed with creating or updating the config map
+    kubectl create configmap "$config_map_name" --from-literal="$uuid_key"="$new_uuid" 2>/dev/null || \
+      kubectl patch configmap "$config_map_name" --type=merge -p "{\"data\":{\"$uuid_key\":\"$new_uuid\"}}"
+
+    # Release the lock
+    kubectl delete configmap "$lock_name"
+
+    echo "$new_uuid"
+    return 0
+  else
+    # Lock not acquired. First make sure we're not dealing with a stale lock.
+    local lock_info=$(kubectl get configmap "$lock_name" -o jsonpath="{.metadata.creationTimestamp} {.metadata.uid}" 2>/dev/null)
+
+    if [[ -n "$lock_info" ]]; then
+      local lock_creation_timestamp=$(echo "$lock_info" | awk '{print $1}')
+      local lock_uid=$(echo "$lock_info" | awk '{print $2}')
+      local current_timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+      local lock_age=$(($(date -d "$current_timestamp" +%s) - $(date -d "$lock_creation_timestamp" +%s)))
+
+      if ((lock_age > lock_timeout)); then
+        # Stale lock detected, attempt to delete it using the UID
+        kubectl delete configmap --uid="$lock_uid"
+
+        # Retry the whole process from the beginning
+        get_or_create_cluster_uuid
+        return $?
+      fi
+    fi
+
+    # Lock is still valid or has been deleted, wait and retry
+    local retry_interval=1
+    local max_retries=5
+
+    for ((i=1; i<=max_retries; i++)); do
+      sleep "$retry_interval"
+
+      uuid=$(kubectl get configmap "$config_map_name" -o jsonpath="{.data.$uuid_key}" 2>/dev/null)
+
+      if [[ -n "$uuid" ]]; then
+        echo "$uuid"
+        return 0
+      fi
+    done
+
+    echo "Failed to retrieve or create the cluster UUID after $max_retries retries" >&2
+    exit 1
+  fi
 }
 
 # some optional commandline args
@@ -82,6 +152,8 @@ echo "Email:          $EMAIL"
 echo "Token:          $TOKEN"
 echo "Cloud:          $CLOUDPROVIDER"
 echo "Cluster:        $CLUSTER"
+echo "Cloud Region:   $CLOUDREGION"
+echo "Environment:    $ENVIRONMENT"
 echo
 echo "Capture:        $CAPTURE"
 echo "Kappa Sample:   $KAPPA_SAMPLE_RATIO"
@@ -108,18 +180,27 @@ case $ACCOUNTREGION in
         ;;
 esac
 
+echo
+echo "Generating UUID for this installation..."
+UUID=$(get_or_create_cluster_uuid)
+echo "UUID: $UUID"
+echo
+
 sed \
     -e 's/__ACCOUNTREGION__/'"$ACCOUNTREGION"'/g' \
     -e 's/__CAPTURE__/'\"$CAPTURE\"'/g' \
     -e 's/__CLOUDPROVIDER__/'"$CLOUDPROVIDER"'/g' \
+    -e 's/__CLOUDREGION__/'"$CLOUDREGION"'/g' \
     -e 's/__CLUSTER__/'"$CLUSTER"'/g' \
     -e 's/__EMAIL__/'"$EMAIL"'/g' \
+    -e 's/__ENVIRONMENT__/'"$ENVIRONMENT"'/g' \
     -e 's/__GRPCENDPOINT__/'"$GRPCENDPOINT"'/g' \
     -e 's/__KAPPA_SAMPLE_RATIO__/'"$KAPPA_SAMPLE_RATIO"'/g' \
     -e 's/__KUBEMETA_VERSION__/'\"$KUBEMETA_VERSION\"'/g' \
     -e 's/__MAXGRPCPAYLOAD__/'"$MAX_PAYLOAD_SIZE_BYTES"'/g' \
     -e 's/__PLAN__/'"$PLAN"'/g' \
     -e 's/__TOKEN__/'"$TOKEN"'/g' \
+    -e 's/__UUID__/'"$UUID"'/g' \
     kustomization-template.yml > kustomization.yml
 
 # Set kubeconfig and context variables if provided

--- a/kappa-agg.yml
+++ b/kappa-agg.yml
@@ -22,31 +22,51 @@ spec:
             - "agg"
             - "0.0.0.0:4000"
           env:
-            - name: KENTIK_REGION
+            - name: KENTIK_CLOUDPROVIDER
               valueFrom:
                 configMapKeyRef:
-                  name: kappa-config
-                  key: region
-            - name: KENTIK_EMAIL
+                  name: kube-config
+                  key: cloudprovider
+            - name: KENTIK_CLOUDREGION
               valueFrom:
-                secretKeyRef:
-                  name: kentik-api-secrets
-                  key: email
-            - name: KENTIK_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: kentik-api-secrets
-                  key: token
+                configMapKeyRef:
+                  name: kube-config
+                  key: cloudregion
             - name: KENTIK_DEVICE
               valueFrom:
                 configMapKeyRef:
                   name: kappa-config
                   key: device
+            - name: KENTIK_ENVIRONMENT
+              valueFrom:
+                configMapKeyRef:
+                  name: kube-config
+                  key: environment
+            - name: KENTIK_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: kentik-api-secrets
+                  key: email
             - name: KENTIK_PLAN
               valueFrom:
                 configMapKeyRef:
                   name: kappa-config
                   key: plan
+            - name: KENTIK_REGION
+              valueFrom:
+                configMapKeyRef:
+                  name: kappa-config
+                  key: region
+            - name: KENTIK_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: kentik-api-secrets
+                  key: token
+            - name: KENTIK_UUID
+              valueFrom:
+                configMapKeyRef:
+                  name: kube-config
+                  key: uuid
             - name: RUST_LIB_BACKTRACE
               value: "1"
           ports:

--- a/kubemeta.yml
+++ b/kubemeta.yml
@@ -61,16 +61,6 @@ spec:
                 configMapKeyRef:
                   name: kube-config
                   key: cloudprovider
-            - name: KENTIK_EMAIL
-              valueFrom:
-                secretKeyRef:
-                  name: kentik-api-secrets
-                  key: email
-            - name: KENTIK_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: kentik-api-secrets
-                  key: token
             - name: CLUSTER_NAME
               valueFrom:
                 configMapKeyRef:
@@ -81,6 +71,31 @@ spec:
                 configMapKeyRef:
                   name: kube-config
                   key: grpcendpoint
+            - name: KENTIK_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: kentik-api-secrets
+                  key: token
+            - name: KENTIK_CLOUDREGION
+              valueFrom:
+                configMapKeyRef:
+                  name: kube-config
+                  key: cloudregion
+            - name: KENTIK_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: kentik-api-secrets
+                  key: email
+            - name: KENTIK_ENVIRONMENT
+              valueFrom:
+                configMapKeyRef:
+                  name: kube-config
+                  key: environment
+            - name: KENTIK_UUID
+              valueFrom:
+                configMapKeyRef:
+                  name: kube-config
+                  key: uuid
             - name: MAX_PAYLOAD_SIZE
               valueFrom:
                 configMapKeyRef:

--- a/kustomization-template.yml
+++ b/kustomization-template.yml
@@ -29,8 +29,11 @@ configMapGenerator:
   - name: kube-config
     literals:
       - cloudprovider=__CLOUDPROVIDER__
+      - cloudregion=__CLOUDREGION__
+      - environment=__ENVIRONMENT__
       - grpcendpoint=__GRPCENDPOINT__
       - maxgrpcpayload=__MAXGRPCPAYLOAD__
+      - uuid=__UUID__
 patchesJson6902:
 #   - target:
 #       group: "apps"


### PR DESCRIPTION
This PR extends the kube deploy script to add

- CLOUDREGION : e.g., us-west-2 or free form for on prem installations
- ENVIRONMENT : free form organizational layer for companies.  things like 'prod', 'qa', 'staging', 'dev', etc
- UUID : unique per kube deployment.  this is auto-generated by the script and persisted in a configmap in the k8s cluster.  Subsequent calls to the deploy script will retrieve this UUID and continue to use it.

The UUID generation takes steps to prevent race/concurrency conditions on generation in the storage of the UUID in the config map.