### PR TITLE
CPU/RAM resource limits for all kube components

### DIFF
--- a/kappa-agg.yml
+++ b/kappa-agg.yml
@@ -16,6 +16,7 @@ spec:
       containers:
         - name: kappa
           image: kentik/kappa
+          imagePullPolicy: Always
           command: ["/opt/kentik/kappa/kappa"]
           args:
             - "-v"

--- a/kustomization-template.yml
+++ b/kustomization-template.yml
@@ -34,13 +34,66 @@ configMapGenerator:
       - grpcendpoint=__GRPCENDPOINT__
       - maxgrpcpayload=__MAXGRPCPAYLOAD__
       - uuid=__UUID__
-patchesJson6902:
+# patchesJson6902:
 #   - target:
 #       group: "apps"
 #       version: v1
 #       kind: DaemonSet
 #       name: kappa-agent
 #     path: kappa-bytecode.yml
+patches:
+  - target:
+      kind: DaemonSet
+      name: kappa-agent
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: __KAPPA_AGENT_CPU_REQUEST__
+            memory: __KAPPA_AGENT_MEM_REQUEST__
+          limits:
+            cpu: __KAPPA_AGENT_CPU_LIMIT__
+            memory: __KAPPA_AGENT_MEM_LIMIT__
+  - target:
+      kind: Deployment
+      name: kappa-agg
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: __KAPPA_AGG_CPU_REQUEST__
+            memory: __KAPPA_AGG_MEM_REQUEST__
+          limits:
+            cpu: __KAPPA_AGG_CPU_LIMIT__
+            memory: __KAPPA_AGG_MEM_LIMIT__
+  - target:
+      kind: Deployment
+      name: kubeinfo
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: __KUBEINFO_CPU_REQUEST__
+            memory: __KUBEINFO_MEM_REQUEST__
+          limits:
+            cpu: __KUBEINFO_CPU_LIMIT__
+            memory: __KUBEINFO_MEM_LIMIT__
+  - target:
+      kind: Deployment
+      name: kubemeta-deployment
+    patch: |-
+      - op: add
+        path: /spec/template/spec/containers/0/resources
+        value:
+          requests:
+            cpu: __KUBEMETA_CPU_REQUEST__
+            memory: __KUBEMETA_MEM_REQUEST__
+          limits:
+            cpu: __KUBEMETA_CPU_LIMIT__
+            memory: __KUBEMETA_MEM_LIMIT__
 secretGenerator:
   - name: kentik-api-secrets
     literals:


### PR DESCRIPTION
This change adds configurable CPU/RAM resource limitations for all kube components.

`deploy-kube.sh` remains the single point of configuration.  Each component can have their CPU and RAM request and limit values set explicitly.   Default values should handle most deploys, though users are free to modify these values as is appropriate for their environment.

Also, grpc payload limit has been bumped to match the current max utilized by ui-app (64MB).