### PR TITLE
kube: cpu/mem resource controls are now optional

### DIFF
--- a/kustomization-template.yml
+++ b/kustomization-template.yml
@@ -41,59 +41,6 @@ configMapGenerator:
 #       kind: DaemonSet
 #       name: kappa-agent
 #     path: kappa-bytecode.yml
-patches:
-  - target:
-      kind: DaemonSet
-      name: kappa-agent
-    patch: |-
-      - op: add
-        path: /spec/template/spec/containers/0/resources
-        value:
-          requests:
-            cpu: __KAPPA_AGENT_CPU_REQUEST__
-            memory: __KAPPA_AGENT_MEM_REQUEST__
-          limits:
-            cpu: __KAPPA_AGENT_CPU_LIMIT__
-            memory: __KAPPA_AGENT_MEM_LIMIT__
-  - target:
-      kind: Deployment
-      name: kappa-agg
-    patch: |-
-      - op: add
-        path: /spec/template/spec/containers/0/resources
-        value:
-          requests:
-            cpu: __KAPPA_AGG_CPU_REQUEST__
-            memory: __KAPPA_AGG_MEM_REQUEST__
-          limits:
-            cpu: __KAPPA_AGG_CPU_LIMIT__
-            memory: __KAPPA_AGG_MEM_LIMIT__
-  - target:
-      kind: Deployment
-      name: kubeinfo
-    patch: |-
-      - op: add
-        path: /spec/template/spec/containers/0/resources
-        value:
-          requests:
-            cpu: __KUBEINFO_CPU_REQUEST__
-            memory: __KUBEINFO_MEM_REQUEST__
-          limits:
-            cpu: __KUBEINFO_CPU_LIMIT__
-            memory: __KUBEINFO_MEM_LIMIT__
-  - target:
-      kind: Deployment
-      name: kubemeta-deployment
-    patch: |-
-      - op: add
-        path: /spec/template/spec/containers/0/resources
-        value:
-          requests:
-            cpu: __KUBEMETA_CPU_REQUEST__
-            memory: __KUBEMETA_MEM_REQUEST__
-          limits:
-            cpu: __KUBEMETA_CPU_LIMIT__
-            memory: __KUBEMETA_MEM_LIMIT__
 secretGenerator:
   - name: kentik-api-secrets
     literals:


### PR DESCRIPTION
`deploy-kube.sh` has been modified to only generate resource control yml patches for resources that are uncommented in the script.

Any resource (e.g., CPU limit) that is left commented out will not have a resource control applied to it in the yaml file for that component.

Example:
```
# KAPPA_AGG_CPU_REQUEST=5m        # default: 5m
# KAPPA_AGG_CPU_LIMIT=50m         # default: 50m
# KAPPA_AGG_MEM_REQUEST=100Mi     # default: 100Mi
# KAPPA_AGG_MEM_LIMIT=1Gi         # default: 1Gi
```
There will be no resource limits applied to `kappa_agg`
<br>
```
KAPPA_AGG_CPU_REQUEST=5m        # default: 5m
# KAPPA_AGG_CPU_LIMIT=50m         # default: 50m
KAPPA_AGG_MEM_REQUEST=100Mi     # default: 100Mi
KAPPA_AGG_MEM_LIMIT=1Gi         # default: 1Gi
```
CPU request, as well as mem request and mem limit values will be set, but CPU limit will remain unset.

Fixes: https://github.com/kentik/kentik-kube-deploy/issues/24

### Proof
With all resource controls commented out (default):
```
# KAPPA_AGG_CPU_REQUEST=5m        # default: 5m
# KAPPA_AGG_CPU_LIMIT=50m         # default: 50m
# KAPPA_AGG_MEM_REQUEST=100Mi     # default: 100Mi
# KAPPA_AGG_MEM_LIMIT=1Gi         # default: 1Gi
```
... etc
<br>
The following kustomization.yml file is generated:
```
namespace: kentik
resources:
  - namespace.yml
  - kappa-agent.yml
  - kappa-agg.yml
  - kubeinfo.yml
  - kubemeta.yml
images:
  - name: kentik/kappa
    newTag: "1.1.4"
  - name: kentik/kubeinfo
    newTag: "1.0.1"
  - name: kentik/kubemeta
    newTag: sha-63a15e9
configMapGenerator:
  - name: kappa-config
    literals:
      - capture=en*|veth.*|eth*
      - device=jsd-test-minikube
      - region=US
      - plan=5354
      - sampleratio=1:4
      - bytecode=x86_64/kappa_bpf-ubuntu-5.4.o
  - name: kappa-init
    files:
      - init/exec
      - init/fetch
      - init/trace
  - name: kube-config
    literals:
      - cloudprovider=prem
      - cloudregion=my-mbp-1
      - environment=dev
      - grpcendpoint=grpc.api.kentik.com
      - maxgrpcpayload=67108864
      - uuid=abc-123
# patchesJson6902:
#   - target:
#       group: "apps"
#       version: v1
#       kind: DaemonSet
#       name: kappa-agent
#     path: kappa-bytecode.yml
secretGenerator:
  - name: kentik-api-secrets
    literals:
      - email=**redacted**
      - token=**redacted**
```
Note the absence of any resource controls.
<br>
When we uncomment three resources for kappa_agg:
```
KAPPA_AGG_CPU_REQUEST=5m        # default: 5m
# KAPPA_AGG_CPU_LIMIT=50m         # default: 50m
KAPPA_AGG_MEM_REQUEST=100Mi     # default: 100Mi
KAPPA_AGG_MEM_LIMIT=1Gi         # default: 1Gi
```
<br>

the following patches section is appended to that same yaml file:
```
secretGenerator:
  - name: kentik-api-secrets
    literals:
      - email=**redacted**
      - token=**redacted**
patches:
  - target:
      kind: Deployment
      name: kappa-agg
    patch: |-
      - op: add
        path: /spec/template/spec/containers/0/resources
        value:
          requests:
            cpu: 5m
            memory: 100Mi
          limits:
            memory: 1Gi
```
Note the inclusion of the cpu/mem requests and the mem limit for kappa-agg