### PR TITLE
increase kubemeta grpc payload max to 256MB

### DIFF
--- a/deploy-kube.sh
+++ b/deploy-kube.sh
@@ -26,7 +26,7 @@ CLUSTER=your_cluster_name
 #
 CAPTURE='en*|veth.*|eth*'
 KUBEMETA_VERSION=sha-63a15e9
-MAX_PAYLOAD_SIZE_MB=64
+MAX_PAYLOAD_SIZE_MB=256
 KAPPA_SAMPLE_RATIO=1:4
 
 # ##############################################################################


### PR DESCRIPTION
Until we move to a streaming model (covered by https://github.com/kentik/kubemeta/issues/34 and https://github.com/kentik/kubemeta/issues/39) we need to bump the grpc payload limit to accommodate larger k8s environments for a POV blocker.